### PR TITLE
Support urlsafe base64

### DIFF
--- a/lib/symmetric_encryption/encoder.rb
+++ b/lib/symmetric_encryption/encoder.rb
@@ -6,6 +6,8 @@ module SymmetricEncryption
         Base64.new
       when :base64strict
         Base64Strict.new
+      when :base64urlsafe
+        Base64UrlSafe.new
       when :base16
         Base16.new
       when :none
@@ -61,6 +63,22 @@ module SymmetricEncryption
         return encoded_string if encoded_string.nil? || (encoded_string == "")
 
         decoded_string = ::Base64.decode64(encoded_string)
+        decoded_string.force_encoding(SymmetricEncryption::BINARY_ENCODING)
+      end
+    end
+
+    class Base64UrlSafe
+      def encode(binary_string)
+        return binary_string if binary_string.nil? || (binary_string == "")
+
+        encoded_string = ::Base64.urlsafe_encode64(binary_string)
+        encoded_string.force_encoding(SymmetricEncryption::UTF8_ENCODING)
+      end
+
+      def decode(encoded_string)
+        return encoded_string if encoded_string.nil? || (encoded_string == "")
+
+        decoded_string = ::Base64.urlsafe_decode64(encoded_string)
         decoded_string.force_encoding(SymmetricEncryption::BINARY_ENCODING)
       end
     end

--- a/test/encoder_test.rb
+++ b/test/encoder_test.rb
@@ -4,7 +4,7 @@ require_relative "test_helper"
 #
 class EncoderTest < Minitest::Test
   describe SymmetricEncryption::Encoder do
-    %i[none base64 base64strict base16].each do |encoding|
+    %i[none base64 base64strict base64urlsafe base16].each do |encoding|
       describe "encoding: #{encoding}" do
         before do
           @data         = "987654321"
@@ -13,6 +13,8 @@ class EncoderTest < Minitest::Test
             when :base64
               "OTg3NjU0MzIx\n"
             when :base64strict
+              "OTg3NjU0MzIx"
+            when :base64urlsafe
               "OTg3NjU0MzIx"
             when :base16
               "393837363534333231"

--- a/test/encoder_test.rb
+++ b/test/encoder_test.rb
@@ -7,17 +7,17 @@ class EncoderTest < Minitest::Test
     %i[none base64 base64strict base64urlsafe base16].each do |encoding|
       describe "encoding: #{encoding}" do
         before do
-          @data         = "987654321"
+          @data         = "987654321ts?>>>"
           @data_encoded =
             case encoding
             when :base64
-              "OTg3NjU0MzIx\n"
+              "OTg3NjU0MzIxdHM/Pj4+\n"
             when :base64strict
-              "OTg3NjU0MzIx"
+              "OTg3NjU0MzIxdHM/Pj4+"
             when :base64urlsafe
-              "OTg3NjU0MzIx"
+              "OTg3NjU0MzIxdHM_Pj4-"
             when :base16
-              "393837363534333231"
+              "39383736353433323174733f3e3e3e"
             when :none
               @data
             end


### PR DESCRIPTION
### Description of changes
Add support for urlsafe_base64.

I modified the string used in the test case slightly to explicitly show the difference in results depending on the encoding method



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
