### PR TITLE
Fix for attribute_changed? and saved_change_to_attribute in Rails 7

### DIFF
--- a/lib/symmetric_encryption/active_record/encrypted_attribute.rb
+++ b/lib/symmetric_encryption/active_record/encrypted_attribute.rb
@@ -24,6 +24,10 @@ module SymmetricEncryption
         )
       end
 
+      def changed_in_place?(raw_old_value, new_value)
+        deserialize(raw_old_value) != new_value
+      end
+
       private
 
       # Symmetric Encryption uses coercible gem to handle casting

--- a/test/active_record/encrypted_attribute_test.rb
+++ b/test/active_record/encrypted_attribute_test.rb
@@ -107,6 +107,24 @@ class EncryptedAttributeTest < Minitest::Test
       refute_equal iv1, iv2
     end
 
+    it "reports whether it has changed" do
+      person.name # Call field so decryption happens
+      assert !person.name_changed?
+
+      person.name = "Abcde fghij"
+      assert person.name_changed?
+    end
+
+    it "reports whether it has changed since last save" do
+      person.reload
+      person.name # Call field so decryption happens
+      assert !person.saved_change_to_name?
+
+      person.update!(address: "Some other test value")
+      assert !person.saved_change_to_name?
+      assert person.saved_change_to_address?
+    end
+
     describe "types" do
       it "serializes" do
         assert_equal person_name, person.name


### PR DESCRIPTION
### Issue
In Rails 7 when reading an attribute the decryption occurs so the #{attribute}_changed? and saved_change_to_#{attribute}_changed? methods will report a change even if it hasn't happened.  This PR addresses that.

### Description of changes
Added `changed_in_place?` method to `SymmetricEncryption::ActiveRecord::EncryptedAttribute` so it handles the string change correctly according to the Rails attributes docs: https://github.com/rails/rails/blob/main/activemodel/lib/active_model/type/value.rb#L84

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
