### PR TITLE
Fix migration of ciphers that use `encrypted_iv`

### DIFF
--- a/lib/symmetric_encryption/keystore.rb
+++ b/lib/symmetric_encryption/keystore.rb
@@ -220,8 +220,7 @@ module SymmetricEncryption
 
       # Migrate old encrypted_iv
       if (encrypted_iv = config.delete(:encrypted_iv)) && private_rsa_key
-        encrypted_iv = RSAKey.new(private_rsa_key).decrypt(encrypted_iv)
-        config[:iv]  = ::Base64.decode64(encrypted_iv)
+        config[:iv] = RSAKey.new(private_rsa_key).decrypt(::Base64.decode64(encrypted_iv))
       end
 
       # Migrate old iv_filename

--- a/test/config/symmetric-encryption.yml
+++ b/test/config/symmetric-encryption.yml
@@ -142,3 +142,37 @@ test:
         PnGA91G9MVikYapgI0VYBHQOTsz8rTIUzsKwXG+TIaK+W84nxH5y6jUkjqwxZmAz
         r1URaMAun2PfAB4g2N/kEZTExgeOGqXjFhvvjdzl97ux2cTyZhaTXg==
         -----END RSA PRIVATE KEY-----
+    - encrypted_key: xFAsZ73PThktyo76PoNQGYnjCJUAd4+Yaz71bO5FajshXsbjkfZjjvbK9hxzWLr+C7X67hcrTypVHB1Rw0De8lRDqexlc87sTx1wtlz70lOvTBXt9Lv4sbJNLxacuqk545LIJpgK02Dq7FGzACV3jb3Yk+QQngiscETYM6PyiuFpReFB0qFOgCSLeBJsXAdNdqkEZggl8PL+lGDueDGeKUng+Ic/AFWPhJGYkk3xV++AGwUFXdDQeuHllxmV9WlzriHnDwzbfugkfGaRjWn808VXrv9Jgf2yRy++gOYUvRnjZ1ltOgXUEEmBVF2Uvhu+zs6C/D4cb1mkR7911M5naA==
+      encrypted_iv: gqdpr50QcG1Y/RtRImAK4TY7hlkJJFgHPNoUYg+knUvXtm0bZMnpUWGi2YKQVAL0KKwz744tLcwvRg/f93f+OBYZpVGBeTn+YXj1Mi9ph5ocy7kjM0WnsY13WIAmSgrOM5DsbK4DKu80tXQWkBm062DmL0v4d7IoqUaJj4nrU5icqHFSM2LS0KKF7p9fE96J1MlmIRQdLvHjuZBttf2rvPIvuomirOyxWty7ZVjXwumAIp1fWimiglLPRYtdUEBwEsQiY6f99C8iSL/Ph224ISbO+dqcdpsEduMOR55Y/Pwjm5SknanJjYCE6q5TPgOrVD8n2ky4lcir+O33yQrFUA==
+      cipher_name: aes-128-cbc
+      encoding: base64strict
+      version: 1
+      always_add_header: false
+      key_encrypting_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpAIBAAKCAQEAxIL9H/jYUGpA38v6PowRSRJEo3aNVXULNM/QNRpx2DTf++KH
+        6DcuFTFcNSSSxG9n4y7tKi755be8N0uwCCuOzvXqfWmXYjbLwK3Ib2vm0btpHyvA
+        qxgqeJOOCxKdW/cUFLWn0tACUcEjVCNfWEGaFyvkOUuR7Ub9KfhbW9cZO3BxZMUf
+        IPGlHl/gWyf484sXygd+S7cpDTRRzo9RjG74DwfE0MFGf9a1fTkxnSgeOJ6asTOy
+        fp9tEToUlbglKaYGpOGHYQ9TV5ZsyJ9jRUyb4SP5wK2eK6dHTxTcHvT03kD90Hv4
+        WeKIXv3WOjkwNEyMdpnJJfSDb5oquQvCNi7ZSQIDAQABAoIBAQCbzR7TUoBugU+e
+        ICLvpC2wOYOh9kRoFLwlyv3QnH7WZFWRZzFJszYeJ1xr5etXQtyjCnmOkGAg+WOI
+        k8GlOKOpAuA/PpB/leJFiYL4lBwU/PmDdTT0cdx6bMKZlNCeMW8CXGQKiFDOcMqJ
+        0uGtH5YD+RChPIEeFsJxnC8SyZ9/t2ra7XnMGiCZvRXIUDSEIIsRx/mOymJ7bL+h
+        Lbp46IfXf6ZuIzwzoIk0JReV/r+wdmkAVDkrrMkCmVS4/X1wN/Tiik9/yvbsh/CL
+        ztC55eSIEjATkWxnXfPASZN6oUfQPEveGH3HzNjdncjH/Ho8FaNMIAfFpBhhLPi9
+        nG5sbH+BAoGBAOdoUyVoAA/QUa3/FkQaa7Ajjehe5MR5k6VtaGtcxrLiBjrNR7x+
+        nqlZlGvWDMiCz49dgj+G1Qk1bbYrZLRX/Hjeqy5dZOGLMfgf9eKUmS1rDwAzBMcj
+        M9jnnJEBx8HIlNzaR6wzp3GMd0rrccs660A8URvzkgo9qNbvMLq9vyUtAoGBANll
+        SY1Iv9uaIz8klTXU9YzYtsfUmgXzw7K8StPdbEbo8F1J3JPJB4D7QHF0ObIaSWuf
+        suZqLsvWlYGuJeyX2ntlBN82ORfvUdOrdrbDlmPyj4PfFVl0AK3U3Ai374DNrjKR
+        hF6YFm4TLDaJhUjeV5C43kbE1N2FAMS9LYtPJ44NAoGAFDGHZ/E+aCLerddfwwun
+        MBS6MnftcLPHTZ1RimTrNfsBXipBw1ItWEvn5s0kCm9X24PmdNK4TnhqHYaF4DL5
+        ZjbQK1idEA2Mi8GGPIKJJ2x7P6I0HYiV4qy7fe/w1ZlCXE90B7PuPbtrQY9wO7Ll
+        ipJ45X6I1PnyfOcckn8yafUCgYACtPAlgjJhWZn2v03cTbqA9nHQKyV/zXkyUIXd
+        /XPLrjrP7ouAi5A8WuSChR/yx8ECRgrEM65Be3qBEtoGCB4AS1G0NcigM6qhKBFi
+        VS0aMXr3+V8argcUIwJaWW/x+p2go48yXlJpLHPweeXe8mXEt4iM+QZte6p2yKQ4
+        h9PGQQKBgQCqSydmXBnXGIVTp2sH/2GnpxLYnDBpcJE0tM8bJ42HEQQgRThIChsn
+        PnGA91G9MVikYapgI0VYBHQOTsz8rTIUzsKwXG+TIaK+W84nxH5y6jUkjqwxZmAz
+        r1URaMAun2PfAB4g2N/kEZTExgeOGqXjFhvvjdzl97ux2cTyZhaTXg==
+        -----END RSA PRIVATE KEY-----


### PR DESCRIPTION
### Issue # (if available)

#83 (I think).

### Description of changes

We need to base64 decode this string before trying to decrypt it.

Without this change we end up with errors that look like:

```
/Users/sam/.rbenv/versions/3.1.2/lib/ruby/3.1.0/openssl/pkey.rb:430:in `private_decrypt'
        from /Users/sam/src/symmetric-encryption/lib/symmetric_encryption/rsa_key.rb:17:in `decrypt'
        from /Users/sam/src/symmetric-encryption/lib/symmetric_encryption/keystore.rb:223:in `migrate_config!'
        from /Users/sam/src/symmetric-encryption/lib/symmetric_encryption/cipher.rb:21:in `from_config'
        from /Users/sam/src/symmetric-encryption/lib/symmetric_encryption/config.rb:88:in `block in ciphers'
        from /Users/sam/src/symmetric-encryption/lib/symmetric_encryption/config.rb:88:in `collect'
        from /Users/sam/src/symmetric-encryption/lib/symmetric_encryption/config.rb:88:in `ciphers'
        from /Users/sam/src/symmetric-encryption/lib/symmetric_encryption/config.rb:22:in `load!'
        from /Users/sam/src/symmetric-encryption/lib/symmetric_encryption/symmetric_encryption.rb:294:in `load!'
        from /Users/sam/src/symmetric-encryption/test/test_helper.rb:18:in `<top (required)>'
        from /Users/sam/src/symmetric-encryption/test/active_record/encrypted_attribute_test.rb:1:in `require_relative'
        from /Users/sam/src/symmetric-encryption/test/active_record/encrypted_attribute_test.rb:1:in `<top (required)>'
        from /Users/sam/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `require'
        from /Users/sam/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
        from /Users/sam/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
        from /Users/sam/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
```

I generated the test string using:

```
$ base64 test/config/test_new.iv
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
