### PR TITLE
- Update activerecord to 7.0.4 to support rails 7.0.4

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -30,8 +30,8 @@ appraise "rails_6.1" do
   gem "google-cloud-kms", platform: :ruby
 end
 
-appraise "rails_7.0" do
-  gem "activerecord", "~> 7.0"
+appraise "rails_7.0.4" do
+  gem "activerecord", "~> 7.0.4"
   gem "mongoid", "~> 7.4.0"
   gem "sqlite3", "~> 1.4.0", platform: :ruby
   gem "google-cloud-kms", platform: :ruby

--- a/Appraisals
+++ b/Appraisals
@@ -30,8 +30,8 @@ appraise "rails_6.1" do
   gem "google-cloud-kms", platform: :ruby
 end
 
-appraise "rails_7.0.4" do
-  gem "activerecord", "~> 7.0.4"
+appraise "rails_7.0.0" do
+  gem "activerecord", "~> 7.0.0"
   gem "mongoid", "~> 7.4.0"
   gem "sqlite3", "~> 1.4.0", platform: :ruby
   gem "google-cloud-kms", platform: :ruby

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "activerecord", "~> 7.0"
+gem "activerecord", "~> 7.0.4"
 gem "mongoid", "~> 7.4.0"
 gem "sqlite3", "~> 1.4.0", platform: :ruby
 gem "google-cloud-kms", platform: :ruby

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "activerecord", "~> 7.0.4"
+gem "activerecord", "~> 7.0.0"
 gem "mongoid", "~> 7.4.0"
 gem "sqlite3", "~> 1.4.0", platform: :ruby
 gem "google-cloud-kms", platform: :ruby

--- a/lib/symmetric_encryption.rb
+++ b/lib/symmetric_encryption.rb
@@ -18,7 +18,7 @@ begin
     end
 
     # Remove old way of defining attributes with Rails 7 since it conflicts with the method names.
-    if ActiveRecord.version <= Gem::Version.new("7.0.0")
+    if ActiveRecord.version <= Gem::Version.new("7.0.4")
       ActiveRecord::Base.include(SymmetricEncryption::ActiveRecord::AttrEncrypted)
     end
   end

--- a/lib/symmetric_encryption/active_record/attr_encrypted.rb
+++ b/lib/symmetric_encryption/active_record/attr_encrypted.rb
@@ -63,7 +63,8 @@ module SymmetricEncryption
               type:      type,
               compress:  compress
             )
-            encrypted_attributes[attribute.to_sym] = "encrypted_#{attribute}".to_sym
+            encrypted_attrs[attribute.to_sym] = "encrypted_#{attribute}".to_sym
+            self.encrypted_attributes = encrypted_attrs
           end
         end
 
@@ -77,20 +78,20 @@ module SymmetricEncryption
         #   end
         #
         #   User.encrypted_attributes  =>  { email: encrypted_email }
-        def encrypted_attributes
-          @encrypted_attributes ||= superclass.respond_to?(:encrypted_attributes) ? superclass.encrypted_attributes.dup : {}
+        def encrypted_attrs
+          @encrypted_attrs ||= superclass.respond_to?(:encrypted_attributes) && superclass.encrypted_attributes ? superclass.encrypted_attributes.dup : {}
         end
 
         # Return the name of all encrypted virtual attributes as an Array of symbols
         # Example: [:email, :password]
         def encrypted_keys
-          @encrypted_keys ||= encrypted_attributes.keys
+          @encrypted_keys ||= encrypted_attrs.keys
         end
 
         # Return the name of all encrypted columns as an Array of symbols
         # Example: [:encrypted_email, :encrypted_password]
         def encrypted_columns
-          @encrypted_columns ||= encrypted_attributes.values
+          @encrypted_columns ||= encrypted_attrs.values
         end
 
         # Returns whether an attribute has been configured to be encrypted

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-if ActiveRecord.version <= Gem::Version.new("7.0.0")
+if ActiveRecord.version <= Gem::Version.new("7.0.4")
 
   ActiveRecord::Base.configurations = YAML.safe_load(ERB.new(IO.read("test/config/database.yml")).result)
   ActiveRecord::Base.establish_connection(:test)


### PR DESCRIPTION
### Issue # (if available)
It's not working for my Rails 7.0.4 application

### Description of changes
Update gem `activerecord` to `7.0.4`
And make sure it works with rails latest version.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.